### PR TITLE
Add Option for @Generable From Foundation Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,30 @@ let iterator = try TokenIterator(input: input, model: context.model, processor: 
 
 You can find more usage examples in the `MLXStructuredCLI` target and in the unit tests.
 
+### Using @Generable (iOS 26 / macOS 26)
+
+By default the demo feeds the tokenizer a plain JSON schema string. If you build against the iOS 26 / macOS 26 SDKs (the only ones that ship the FoundationModels framework) you can opt into the `@Generable` schema and decode the result into the `MovieRecord` struct by passing `--use-generable-schema`.
+
+## CLI Demo
+
+Build and run the example tool:
+
+```shell
+swift run MLXStructuredCLI generate
+```
+
+Use the regular schema:
+
+```shell
+swift run MLXStructuredCLI generate
+```
+
+Switch to the `@Generable` flow (macOS 26 / iOS 26 SDKs required):
+
+```shell
+swift run MLXStructuredCLI generate --use-generable-schema
+```
+
 ## Experiments
 
 ### Performance

--- a/Sources/MLXStructured/Grammar+Generable.swift
+++ b/Sources/MLXStructured/Grammar+Generable.swift
@@ -1,0 +1,29 @@
+//
+//  Grammar+Generable.swift
+//  MLXStructured
+//
+//  Created by Codex on 22.02.2026.
+//
+
+import Foundation
+
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+#if compiler(>=6.2)
+@available(macOS 26.0, iOS 26.0, *)
+public extension Grammar {
+    static func schema<Content: Generable>(generable type: Content.Type) throws -> Grammar {
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(type.generationSchema)
+        guard let string = String(data: data, encoding: .utf8) else {
+            throw EncodingError.invalidValue(
+                type,
+                EncodingError.Context(codingPath: [], debugDescription: "Failed to encode generation schema using UTF-8.")
+            )
+        }
+        return .schema(string)
+    }
+}
+#endif

--- a/Sources/MLXStructured/Grammar+Generable.swift
+++ b/Sources/MLXStructured/Grammar+Generable.swift
@@ -2,7 +2,7 @@
 //  Grammar+Generable.swift
 //  MLXStructured
 //
-//  Created by Codex on 22.02.2026.
+//  Created by Rudrank Riyam on 21.09.2025.
 //
 
 import Foundation

--- a/Sources/MLXStructuredCLI/GenerateStructuredOutputCommand.swift
+++ b/Sources/MLXStructuredCLI/GenerateStructuredOutputCommand.swift
@@ -13,6 +13,7 @@ import MLXLMCommon
 import MLXLLM
 import MLX
 import Hub
+import FoundationModels
 
 @main
 struct GenerateStructuredOutputCommand: AsyncParsableCommand {
@@ -22,35 +23,20 @@ struct GenerateStructuredOutputCommand: AsyncParsableCommand {
         abstract: "Generates structured output using constrained decoding."
     )
     
+    @Flag(name: .long, help: "Use @Generable MovieRecord type (requires macOS 26 / iOS 26).")
+    var useGenerableSchema = false
+
     func run() async throws {
 //        let configuration = ModelConfiguration(id: "mlx-community/Qwen3-4B-Instruct-2507-4bit")
 //        let configuration = ModelConfiguration(id: "mlx-community/Llama-3.2-3B-Instruct-4bit")
-        let configuration = ModelConfiguration(id: "mlx-community/gemma-3-270m-it-4bit", extraEOSTokens: ["<end_of_turn>"])
+//        let configuration = ModelConfiguration(id: "mlx-community/gemma-3-270m-it-4bit", extraEOSTokens: ["<end_of_turn>"])
+        let configuration = ModelConfiguration(id: "Qwen/Qwen3-1.7B-MLX-4bit")
         let context = try await LLMModelFactory.shared.load(configuration: configuration) { progress in
-            print("Loading model: \(progress.fractionCompleted.formatted(.percent))")
+            debugPrint("Loading model: \(progress.fractionCompleted.formatted(.percent))")
         }
         
-        let grammar = try Grammar.schema(.object(
-            description: "Movie record",
-            properties: [
-                "title": .string(),
-                "year": .integer(),
-                "genres": .array(items: .string(), maxItems: 3),
-                "director": .string(),
-                "actors": .array(items: .string(), maxItems: 10)
-            ], required: [
-                "title",
-                "year",
-                "genres",
-                "director",
-                "actors"
-            ]
-        ))
-        
-        let prompt = """
-        Instruction: Extract movie record from the text, output in JSON format according to schema: \(grammar.raw)
-        Text: The Dark Knight (2008) is a superhero crime film directed by Christopher Nolan. Starring Christian Bale, Heath Ledger, and Michael Caine. 
-        """
+        let grammar = try MovieRecordDemo.makeGrammar(useGenerable: useGenerableSchema)
+        let prompt = MovieRecordDemo.prompt(schema: grammar)
         
         // Plain generation
         do {
@@ -62,8 +48,8 @@ struct GenerateStructuredOutputCommand: AsyncParsableCommand {
                 outputTokens.append(token)
                 return .more
             }
-            print(completionInfo.summary())
-            print("Plain generation:", context.tokenizer.decode(tokens: outputTokens))
+            debugPrint(completionInfo.summary())
+            debugPrint("Plain generation:", context.tokenizer.decode(tokens: outputTokens))
         }
         
         // Constrained generation
@@ -77,8 +63,26 @@ struct GenerateStructuredOutputCommand: AsyncParsableCommand {
                 outputTokens.append(token)
                 return .more
             }
-            print(completionInfo.summary())
-            print("Constrained generation:", context.tokenizer.decode(tokens: outputTokens))
+            debugPrint(completionInfo.summary())
+            let constrained = context.tokenizer.decode(tokens: outputTokens)
+            debugPrint("Constrained generation:", constrained)
+
+            if useGenerableSchema {
+                #if compiler(>=6.2)
+                if #available(macOS 26.0, iOS 26.0, *) {
+                    do {
+                        let record = try MovieRecord(.init(json: constrained))
+                        debugPrint("Parsed movie record:", record)
+                    } catch {
+                        debugPrint("Failed to decode MovieRecord:", error)
+                    }
+                } else {
+                    debugPrint("Warning: Generable decoding requested on an unsupported platform.")
+                }
+                #else
+                print("Warning: Generable decoding requested on an unsupported platform.")
+                #endif
+            }
         }
     }
 }
@@ -88,3 +92,74 @@ struct ArgMaxSampler: LogitSampler {
         argMax(logits, axis: -1)
     }
 }
+
+private enum MovieRecordDemo {
+    private static let context = """
+    Text: The Dark Knight (2008) is a superhero crime film directed by Christopher Nolan. Starring Christian Bale, Heath Ledger, and Michael Caine.
+    """
+
+    static func makeGrammar(useGenerable: Bool) throws -> Grammar {
+        if useGenerable {
+            #if compiler(>=6.2)
+            guard #available(macOS 26.0, iOS 26.0, *) else {
+                throw ValidationError("@Generable schemas require macOS 26 / iOS 26 or later.")
+            }
+            debugPrint("Using @Generable schema for: \(MovieRecord.self)")
+            return try Grammar.schema(generable: MovieRecord.self)
+            #else
+            throw ValidationError("@Generable schemas require Swift 6.2 or later.")
+            #endif
+        } else {
+            return .schema(rawSchema)
+        }
+    }
+
+    private static let rawSchema: String = {
+        let schema = JSONSchema.object(
+            description: "Movie record",
+            properties: [
+                "title": .string(),
+                "year": .integer(),
+                "genres": .array(items: .string(), maxItems: 3),
+                "director": .string(),
+                "actors": .array(items: .string(), maxItems: 10)
+            ],
+            required: ["title", "year", "genres", "director", "actors"]
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(schema),
+              let string = String(data: data, encoding: .utf8) else {
+            fatalError("Failed to build raw JSON schema string for MovieRecord.")
+        }
+        return string
+    }()
+
+    static func prompt(schema: Grammar) -> String {
+        """
+        Instruction: Extract movie record from the text according to schema: \(schema.raw)
+        \(context)
+        """
+    }
+}
+
+#if compiler(>=6.2)
+@available(macOS 26.0, iOS 26.0, *)
+@Generable
+struct MovieRecord: Codable {
+    @Guide(description: "Movie title")
+    let title: String
+
+    @Guide(description: "Release year")
+    let year: Int
+
+    @Guide(description: "List of genres")
+    let genres: [String]
+
+    @Guide(description: "Director name")
+    let director: String
+
+    @Guide(description: "List of principal actors")
+    let actors: [String]
+}
+#endif

--- a/Sources/MLXStructuredCLI/GenerateStructuredOutputCommand.swift
+++ b/Sources/MLXStructuredCLI/GenerateStructuredOutputCommand.swift
@@ -13,7 +13,10 @@ import MLXLMCommon
 import MLXLLM
 import MLX
 import Hub
+
+#if canImport(FoundationModels)
 import FoundationModels
+#endif
 
 @main
 struct GenerateStructuredOutputCommand: AsyncParsableCommand {

--- a/Tests/MLXStructuredTests/TestGenerablePerformance.swift
+++ b/Tests/MLXStructuredTests/TestGenerablePerformance.swift
@@ -1,0 +1,67 @@
+//
+//  TestGenerablePerformance.swift
+//  MLXStructured
+//
+//  Created by Rudrank Riyam on 21.09.2025.
+//
+
+import Testing
+@testable import MLXStructured
+import MLXLMCommon
+import MLXLLM
+import MLX
+
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+#if compiler(>=6.2)
+@available(macOS 26.0, iOS 26.0, *)
+@Generable
+private struct PerformanceRecord: Codable {
+    @Guide(description: "Simple string field")
+    let text: String
+
+    @Guide(description: "Simple integer field")
+    let value: Int
+}
+
+@Test func testGenerableLlamaPerformance() async throws {
+    guard #available(macOS 26.0, iOS 26.0, *) else { return }
+
+    let vocab = ["<eos>"] + (0...0xFFFF).compactMap({ UnicodeScalar($0).map(String.init) })
+    let model = LlamaModel(.init(
+        hiddenSize: 128,
+        hiddenLayers: 16,
+        intermediateSize: 512,
+        attentionHeads: 32,
+        rmsNormEps: 1e-5,
+        vocabularySize: vocab.count,
+        kvHeads: 8
+    ))
+
+    let grammar = try Grammar.schema(generable: PerformanceRecord.self)
+    let grammarMatcher = try XGrammar(vocab: vocab, vocabType: 0, stopTokenIds: [0], grammar: grammar)
+    let processor = GrammarMaskedLogitProcessor(grammarMatcher: grammarMatcher)
+    let sampler = ArgMaxSampler()
+    let input = LMInput(tokens: MLXArray([1, 2, 3, 4, 5]))
+    let maxTokens = 512
+
+    let plainIterator = try TokenIterator(input: input, model: model, processor: nil, sampler: sampler, maxTokens: maxTokens)
+    let clock = ContinuousClock()
+    let plainStart = clock.now
+    let _ = Array(plainIterator)
+    let plainDuration = clock.now - plainStart
+
+    let constrainedIterator = try TokenIterator(input: input, model: model, processor: processor, sampler: sampler, maxTokens: maxTokens)
+    let constrainedStart = clock.now
+    let _ = Array(constrainedIterator)
+    let constrainedDuration = clock.now - constrainedStart
+
+    let slowdown = (constrainedDuration / plainDuration) - 1
+    #expect(slowdown < 0.1)
+    print("Plain duration: \(plainDuration)")
+    print("Generable constrained duration: \(constrainedDuration)")
+    print("Generable constrained decoding slower by \(slowdown.formatted(.percent))")
+}
+#endif


### PR DESCRIPTION
Thank you creating this framework!

I added option to use the Generable macro so that folks can use a single structure for both Foundation Models and MLX as a fallback for structured output