### PR TITLE
Expose IsTerminated() and fix return false in void function

### DIFF
--- a/Sources/CMLXStructured/grammar_matcher.cpp
+++ b/Sources/CMLXStructured/grammar_matcher.cpp
@@ -49,6 +49,16 @@ extern "C" void grammar_matcher_reset(void* grammar_matcher) {
         grammar_matcher_ptr->Reset();
     } catch (const std::exception& e) {
         catch_error(e.what());
+        return;
+    }
+}
+
+extern "C" bool grammar_matcher_is_terminated(void* grammar_matcher) {
+    try {
+        auto* grammar_matcher_ptr = static_cast<GrammarMatcher*>(grammar_matcher);
+        return grammar_matcher_ptr->IsTerminated();
+    } catch (const std::exception& e) {
+        catch_error(e.what());
         return false;
     }
 }

--- a/Sources/CMLXStructured/include/mlx_structured/grammar_matcher.h
+++ b/Sources/CMLXStructured/include/mlx_structured/grammar_matcher.h
@@ -22,6 +22,8 @@ bool grammar_matcher_accept_token(
 
 void grammar_matcher_reset(void* grammar_matcher);
 
+bool grammar_matcher_is_terminated(void* grammar_matcher);
+
 void grammar_matcher_free(void* grammar_matcher);
 
 #ifdef __cplusplus

--- a/Sources/MLXStructured/Backends/XGrammar.swift
+++ b/Sources/MLXStructured/Backends/XGrammar.swift
@@ -164,6 +164,10 @@ extension XGrammar: GrammarMatcher {
     func reset() {
         grammar_matcher_reset(grammarMatcher)
     }
+
+    func isTerminated() -> Bool {
+        return grammar_matcher_is_terminated(grammarMatcher)
+    }
 }
 
 private extension DLTensor {

--- a/Sources/MLXStructured/GrammarMatcher.swift
+++ b/Sources/MLXStructured/GrammarMatcher.swift
@@ -11,4 +11,5 @@ public protocol GrammarMatcher {
     func nextTokenMask() -> MLXArray // 0 or -infinity
     func advance(token: MLXArray)
     func reset()
+    func isTerminated() -> Bool
 }


### PR DESCRIPTION
## Summary

- Expose xgrammar's `GrammarMatcher::IsTerminated()` through the C wrapper and Swift `GrammarMatcher` protocol
- Fix `return false;` in void function `grammar_matcher_reset()` (compilation error with `-Werror=return-mismatch`)

## Problem

The C wrapper (`grammar_matcher.h`) exposes 5 of xgrammar's `GrammarMatcher` methods but omits `IsTerminated()`. This prevents Swift consumers from detecting when grammar-constrained generation has completed. Without this check, the token generation loop continues after the grammar accepts its stop token, producing unconstrained tokens that corrupt the output.

xgrammar exposes `IsTerminated()` in its C++ API (`matcher.h:131`), Python bindings (`nanobind.cc:313`), JavaScript bindings (`xgrammar_binding.cc:178`), and TypeScript wrapper (`xgrammar.ts:518`). The C bridge was the only binding missing it.

## Changes

1. **`grammar_matcher.cpp`**: Fix `return false;` → `return;` in `grammar_matcher_reset()` catch block (void function)
2. **`grammar_matcher.h`**: Add `bool grammar_matcher_is_terminated(void*)` declaration
3. **`grammar_matcher.cpp`**: Add `grammar_matcher_is_terminated()` implementation delegating to `GrammarMatcher::IsTerminated()`
4. **`GrammarMatcher.swift`**: Add `func isTerminated() -> Bool` to protocol
5. **`XGrammar.swift`**: Implement `isTerminated()` calling the C wrapper

## Test plan

- [x] Verified `IsTerminated()` exists in xgrammar C++ API (`matcher.h:131`)
- [x] Confirmed all other bindings (Python, JS, TS) expose it
- [x] Build succeeds with changes
- [ ] Grammar-constrained generation stops cleanly after grammar completion