### PR TITLE
Optimize grammar matcher

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "mlx-swift-structured",
-    platforms: [.macOS(.v14), .iOS(.v16)],
+    platforms: [.macOS(.v14), .iOS(.v17)],
     products: [.library(name: "MLXStructured", targets: ["MLXStructured"])],
     dependencies: [
         .package(url: "https://github.com/ml-explore/mlx-swift", from: "0.25.6"),

--- a/Package.swift
+++ b/Package.swift
@@ -57,6 +57,13 @@ let package = Package(
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
         ),
+        .executableTarget(
+            name: "MLXStructuredBenchmark",
+            dependencies: [
+                .target(name: "CMLXStructured"),
+                .product(name: "JSONSchema", package: "swift-json-schema"),
+            ]
+        ),
         // Unit tests
         .testTarget(
             name: "MLXStructuredTests",

--- a/Sources/CMLXStructured/grammar_matcher.cpp
+++ b/Sources/CMLXStructured/grammar_matcher.cpp
@@ -43,6 +43,18 @@ extern "C" bool grammar_matcher_accept_token(
     }
 }
 
+extern "C" bool grammar_matcher_is_terminated(void* grammar_matcher) {
+    try {
+        auto* grammar_matcher_ptr = static_cast<GrammarMatcher*>(grammar_matcher);
+        return grammar_matcher_ptr->IsTerminated();
+    } catch (const std::exception& e) {
+        catch_error(e.what());
+        return false;
+    }
+}
+
+
+
 extern "C" void grammar_matcher_reset(void* grammar_matcher) {
     try {
         auto* grammar_matcher_ptr = static_cast<GrammarMatcher*>(grammar_matcher);

--- a/Sources/CMLXStructured/grammar_matcher.cpp
+++ b/Sources/CMLXStructured/grammar_matcher.cpp
@@ -61,7 +61,7 @@ extern "C" void grammar_matcher_reset(void* grammar_matcher) {
         grammar_matcher_ptr->Reset();
     } catch (const std::exception& e) {
         catch_error(e.what());
-        return false;
+        return;
     }
 }
 

--- a/Sources/CMLXStructured/grammar_matcher.cpp
+++ b/Sources/CMLXStructured/grammar_matcher.cpp
@@ -1,6 +1,7 @@
 #include "mlx_structured/error_handler.h"
 #include "mlx_structured/grammar_matcher.h"
 #include <dlpack/dlpack.h>
+#include <limits>
 #include <xgrammar/matcher.h>
 
 using namespace xgrammar;
@@ -30,6 +31,40 @@ extern "C" bool grammar_matcher_fill_next_token_bitmask(
     }
 }
 
+extern "C" bool grammar_matcher_fill_next_token_dense_mask(
+    void* grammar_matcher,
+    void* next_token_bitmask,
+    float* next_token_dense_mask,
+    size_t next_token_dense_mask_len
+) {
+    try {
+        auto* grammar_matcher_ptr = static_cast<GrammarMatcher*>(grammar_matcher);
+        auto* next_token_bitmask_ptr = static_cast<DLTensor*>(next_token_bitmask);
+        if (!grammar_matcher_ptr->FillNextTokenBitmask(next_token_bitmask_ptr)) {
+            return false;
+        }
+
+        auto* data_ptr = reinterpret_cast<const uint32_t*>(next_token_bitmask_ptr->data);
+        constexpr size_t bits_per_block = sizeof(uint32_t) * 8;
+        const float negative_infinity = -std::numeric_limits<float>::infinity();
+        const size_t block_count = (next_token_dense_mask_len + bits_per_block - 1) / bits_per_block;
+        for (size_t block_index = 0; block_index < block_count; ++block_index) {
+            const uint32_t block = data_ptr[block_index];
+            const size_t base = block_index * bits_per_block;
+            const size_t limit = std::min(bits_per_block, next_token_dense_mask_len - base);
+            for (size_t bit = 0; bit < limit; ++bit) {
+                next_token_dense_mask[base + bit] = (block & (uint32_t(1) << bit))
+                    ? 0.0f
+                    : negative_infinity;
+            }
+        }
+        return true;
+    } catch (const std::exception& e) {
+        catch_error(e.what());
+        return false;
+    }
+}
+
 extern "C" bool grammar_matcher_accept_token(
     void* grammar_matcher,
     int32_t token_id
@@ -40,6 +75,22 @@ extern "C" bool grammar_matcher_accept_token(
     } catch (const std::exception& e) {
         catch_error(e.what());
         return false;
+    }
+}
+
+extern "C" int8_t grammar_matcher_accept_token_status(
+    void* grammar_matcher,
+    int32_t token_id
+) {
+    try {
+        auto* grammar_matcher_ptr = static_cast<GrammarMatcher*>(grammar_matcher);
+        if (grammar_matcher_ptr->IsTerminated()) {
+            return -1;
+        }
+        return grammar_matcher_ptr->AcceptToken(token_id) ? 1 : 0;
+    } catch (const std::exception& e) {
+        catch_error(e.what());
+        return 0;
     }
 }
 

--- a/Sources/CMLXStructured/include/mlx_structured/grammar_matcher.h
+++ b/Sources/CMLXStructured/include/mlx_structured/grammar_matcher.h
@@ -20,6 +20,8 @@ bool grammar_matcher_accept_token(
     int32_t token_id
 );
 
+bool grammar_matcher_is_terminated(void* grammar_matcher);
+
 void grammar_matcher_reset(void* grammar_matcher);
 
 void grammar_matcher_free(void* grammar_matcher);

--- a/Sources/CMLXStructured/include/mlx_structured/grammar_matcher.h
+++ b/Sources/CMLXStructured/include/mlx_structured/grammar_matcher.h
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -15,7 +16,19 @@ bool grammar_matcher_fill_next_token_bitmask(
     void* next_token_bitmask
 );
 
+bool grammar_matcher_fill_next_token_dense_mask(
+    void* grammar_matcher,
+    void* next_token_bitmask,
+    float* next_token_dense_mask,
+    size_t next_token_dense_mask_len
+);
+
 bool grammar_matcher_accept_token(
+    void* grammar_matcher,
+    int32_t token_id
+);
+
+int8_t grammar_matcher_accept_token_status(
     void* grammar_matcher,
     int32_t token_id
 );

--- a/Sources/MLXStructured/Backends/XGrammar.swift
+++ b/Sources/MLXStructured/Backends/XGrammar.swift
@@ -161,6 +161,10 @@ extension XGrammar: GrammarMatcher {
     }
     
     func advance(token: MLXArray) {
+
+        // Skip if grammar already terminated (stop token accepted).
+        // Prevents C++ warning from AcceptToken on terminated matcher.
+        if grammar_matcher_is_terminated(grammarMatcher) { return }
         let tokenID = token.item(Int32.self)
         let accepted = grammar_matcher_accept_token(grammarMatcher, tokenID)
         if !accepted {

--- a/Sources/MLXStructured/Backends/XGrammar.swift
+++ b/Sources/MLXStructured/Backends/XGrammar.swift
@@ -47,8 +47,8 @@ final class XGrammar {
             
     private let vocabSize: Int
     private let bufferSize: Int
-    private let bitmap: MLXArray
     private var bitmask: DLTensor
+    private var denseMask: [Float]
     private let grammarMatcher: UnsafeMutableRawPointer?
     
     init(
@@ -111,21 +111,14 @@ final class XGrammar {
             throw XGrammarError.invalidGrammar(XGrammar.lastErrorMessage)
         }
         
-        var bitmap = [Float](repeating: 0, count: 256 * 8)
-        for b in 0..<256 {
-            for k in 0..<8 {
-                bitmap[b * 8 + k] = ((b >> k) & 1) == 1 ? 0 : -Float.infinity
-            }
-        }
-        
         guard let grammarMatcher = grammar_matcher_new(compiledGrammar) else {
             throw XGrammarError.unknown(XGrammar.lastErrorMessage)
         }
         
         self.vocabSize = vocab.count
         self.bufferSize = (vocab.count + 31) / 32
-        self.bitmap = MLXArray(bitmap).reshaped([256, 8])
         self.bitmask = DLTensor.nextTokenBitmask(bufferSize: bufferSize)
+        self.denseMask = [Float](repeating: -.infinity, count: vocab.count)
         self.grammarMatcher = grammarMatcher
     }
     
@@ -140,34 +133,26 @@ final class XGrammar {
 extension XGrammar: GrammarMatcher {
     
     func nextTokenMask() -> MLXArray {
-        guard withUnsafeMutablePointer(to: &bitmask, {
-            grammar_matcher_fill_next_token_bitmask(grammarMatcher, $0)
-        }) else {
+        let didFillMask = withUnsafeMutablePointer(to: &bitmask) { bitmaskPointer in
+            denseMask.withUnsafeMutableBufferPointer { denseMaskPointer in
+                grammar_matcher_fill_next_token_dense_mask(
+                    grammarMatcher,
+                    bitmaskPointer,
+                    denseMaskPointer.baseAddress,
+                    denseMaskPointer.count
+                )
+            }
+        }
+        guard didFillMask else {
             return MLXArray.zeros([vocabSize])
         }
-        
-        let bytes = bufferSize &<< 2
-        let bitmaskData = UnsafeRawBufferPointer(start: bitmask.data, count: bytes)
-        let bitmask = MLXArray(bitmaskData, [bytes], type: Int8.self)
-        let expandedCount = bytes * 8
-        let safeCount = min(vocabSize, expandedCount)
-        let mask = bitmap[bitmask].reshaped([expandedCount])[0..<safeCount]
-        if safeCount < vocabSize {
-            // Pad with -inf so logits for extra positions are masked (defensive)
-            let pad = MLXArray([Float](repeating: -Float.infinity, count: vocabSize - safeCount))
-            return MLX.concatenated([mask, pad], axis: 0)
-        }
-        return mask
+        return MLXArray(denseMask)
     }
     
     func advance(token: MLXArray) {
-
-        // Skip if grammar already terminated (stop token accepted).
-        // Prevents C++ warning from AcceptToken on terminated matcher.
-        if grammar_matcher_is_terminated(grammarMatcher) { return }
         let tokenID = token.item(Int32.self)
-        let accepted = grammar_matcher_accept_token(grammarMatcher, tokenID)
-        if !accepted {
+        let status = grammar_matcher_accept_token_status(grammarMatcher, tokenID)
+        if status == 0 {
             reset()
         }
     }

--- a/Sources/MLXStructured/Generate.swift
+++ b/Sources/MLXStructured/Generate.swift
@@ -21,9 +21,35 @@ public func generate(
     grammar: Grammar,
     didGenerate: ([Int]) -> GenerateDisposition = { _ in .more }
 ) async throws -> GenerateResult {
+    return try await generate(
+        input: input,
+        cache: nil,
+        parameters: parameters,
+        context: context,
+        grammar: grammar,
+        didGenerate: didGenerate
+    )
+}
+
+public func generate(
+    input: LMInput,
+    cache: [KVCache]? = nil,
+    parameters: GenerateParameters = GenerateParameters(),
+    context: ModelContext,
+    grammar: Grammar,
+    didGenerate: ([Int]) -> GenerateDisposition = { _ in .more }
+) async throws -> GenerateResult {
     let sampler = parameters.sampler()
     let processor = try await GrammarMaskedLogitProcessor.from(configuration: context.configuration, grammar: grammar)
-    let iterator = try TokenIterator(input: input, model: context.model, processor: processor, sampler: sampler)
+    let iterator = try TokenIterator(
+        input: input,
+        model: context.model,
+        cache: cache,
+        processor: processor,
+        sampler: sampler,
+        prefillStepSize: parameters.prefillStepSize,
+        maxTokens: parameters.maxTokens
+    )
     let result = generate(input: input, context: context, iterator: iterator, didGenerate: didGenerate)
     return result
 }

--- a/Sources/MLXStructuredBenchmark/main.swift
+++ b/Sources/MLXStructuredBenchmark/main.swift
@@ -1,0 +1,362 @@
+import CMLXStructured
+import Foundation
+
+private enum BenchmarkError: Error {
+    case nativeError(String)
+    case initializationFailed(String)
+}
+
+private final class ErrorCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var message: String?
+
+    func set(_ message: String?) {
+        lock.withLock { self.message = message }
+    }
+
+    func take() -> String? {
+        lock.withLock {
+            defer { message = nil }
+            return message
+        }
+    }
+}
+
+private let errorCapture = ErrorCapture()
+
+private let errorHandler: @convention(c) (UnsafePointer<CChar>?) -> Void = { pointer in
+    errorCapture.set(pointer.map { String(cString: $0) })
+}
+
+private struct DLDevice {
+    var deviceType: Int32
+    var deviceId: Int32
+}
+
+private struct DLDataType {
+    var code: UInt8
+    var bits: UInt8
+    var lanes: UInt16
+}
+
+private struct DLTensor {
+    var data: UnsafeMutableRawPointer?
+    var device: DLDevice
+    var ndim: Int32
+    var dtype: DLDataType
+    var shape: UnsafeMutablePointer<Int64>?
+    var strides: UnsafeMutablePointer<Int64>?
+    var byteOffset: UInt64
+
+    static func nextTokenBitmask(bufferSize: Int) -> DLTensor {
+        let dataBytes = bufferSize * MemoryLayout<Int32>.stride
+        let data = UnsafeMutableRawPointer.allocate(byteCount: dataBytes, alignment: 64)
+        data.bindMemory(to: Int32.self, capacity: bufferSize).initialize(repeating: 0, count: bufferSize)
+
+        let shape = UnsafeMutablePointer<Int64>.allocate(capacity: 1)
+        shape.initialize(to: Int64(bufferSize))
+
+        return DLTensor(
+            data: data,
+            device: DLDevice(deviceType: 1, deviceId: 0),
+            ndim: 1,
+            dtype: DLDataType(code: 0, bits: 32, lanes: 1),
+            shape: shape,
+            strides: nil,
+            byteOffset: 0
+        )
+    }
+
+    mutating func deallocate() {
+        data?.deallocate()
+        shape?.deallocate()
+        strides?.deallocate()
+        data = nil
+        shape = nil
+        strides = nil
+    }
+}
+
+private struct NativeMatcher {
+    let vocabSize: Int
+    let bufferSize: Int
+    let matcher: UnsafeMutableRawPointer
+    private let compiledGrammar: UnsafeMutableRawPointer
+    private let tokenizerInfo: UnsafeMutableRawPointer
+    private let duplicatedVocab: [UnsafeMutablePointer<CChar>?]
+
+    init(vocab: [String], stopTokenIds: [Int32], ebnfGrammar: String) throws {
+        let duplicatedVocab = vocab.map { strdup($0) }
+        self.duplicatedVocab = duplicatedVocab
+        self.vocabSize = vocab.count
+        self.bufferSize = (vocab.count + 31) / 32
+
+        let tokenizerInfo = duplicatedVocab.map { pointer in
+            pointer.map { UnsafePointer($0) }
+        }.withUnsafeBufferPointer { vocabBuffer in
+            stopTokenIds.withUnsafeBufferPointer { eosBuffer in
+                tokenizer_info_new(
+                    vocabBuffer.baseAddress,
+                    vocabBuffer.count,
+                    0,
+                    eosBuffer.baseAddress,
+                    eosBuffer.count
+                )
+            }
+        }
+        guard let tokenizerInfo else {
+            Self.cleanup(vocab: duplicatedVocab, tokenizerInfo: nil, compiledGrammar: nil, matcher: nil)
+            throw BenchmarkError.initializationFailed(errorCapture.take() ?? "tokenizer_info_new failed")
+        }
+
+        let compiledGrammar = ebnfGrammar.utf8CString.withUnsafeBufferPointer {
+            compile_ebnf_grammar(tokenizerInfo, $0.baseAddress, $0.count)
+        }
+        guard let compiledGrammar else {
+            Self.cleanup(vocab: duplicatedVocab, tokenizerInfo: tokenizerInfo, compiledGrammar: nil, matcher: nil)
+            throw BenchmarkError.initializationFailed(errorCapture.take() ?? "compile_ebnf_grammar failed")
+        }
+
+        guard let matcher = grammar_matcher_new(compiledGrammar) else {
+            Self.cleanup(vocab: duplicatedVocab, tokenizerInfo: tokenizerInfo, compiledGrammar: compiledGrammar, matcher: nil)
+            throw BenchmarkError.initializationFailed(errorCapture.take() ?? "grammar_matcher_new failed")
+        }
+
+        self.tokenizerInfo = tokenizerInfo
+        self.compiledGrammar = compiledGrammar
+        self.matcher = matcher
+    }
+
+    func reset() {
+        grammar_matcher_reset(matcher)
+    }
+
+    func tearDown() {
+        Self.cleanup(
+            vocab: duplicatedVocab,
+            tokenizerInfo: tokenizerInfo,
+            compiledGrammar: compiledGrammar,
+            matcher: matcher
+        )
+    }
+
+    private static func cleanup(
+        vocab: [UnsafeMutablePointer<CChar>?],
+        tokenizerInfo: UnsafeMutableRawPointer?,
+        compiledGrammar: UnsafeMutableRawPointer?,
+        matcher: UnsafeMutableRawPointer?
+    ) {
+        if let matcher {
+            grammar_matcher_free(matcher)
+        }
+        if let compiledGrammar {
+            compiled_grammar_free(compiledGrammar)
+        }
+        if let tokenizerInfo {
+            tokenizer_info_free(tokenizerInfo)
+        }
+        for pointer in vocab {
+            free(pointer)
+        }
+    }
+}
+
+private struct BenchmarkResult {
+    let label: String
+    let totalSeconds: Double
+    let iterations: Int
+
+    var microsecondsPerIteration: Double {
+        (totalSeconds / Double(iterations)) * 1_000_000
+    }
+}
+
+private func benchmark(label: String, iterations: Int, _ body: () throws -> Void) rethrows -> BenchmarkResult {
+    let clock = ContinuousClock()
+    let start = clock.now
+    for _ in 0..<iterations {
+        try body()
+    }
+    let elapsed = start.duration(to: clock.now)
+    return BenchmarkResult(
+        label: label,
+        totalSeconds: Double(elapsed.components.seconds) + Double(elapsed.components.attoseconds) / 1e18,
+        iterations: iterations
+    )
+}
+
+private func oldSwiftStyleDenseMask(bitmaskTensor: inout DLTensor, vocabSize: Int) -> [Float] {
+    let buffer = UnsafeBufferPointer(
+        start: bitmaskTensor.data?.assumingMemoryBound(to: Int32.self),
+        count: (vocabSize + 31) / 32
+    )
+    var mask = [Float](repeating: -.infinity, count: vocabSize)
+    for tokenID in 0..<vocabSize {
+        let block = tokenID >> 5
+        let bit = tokenID & 31
+        if (UInt32(bitPattern: buffer[block]) & (UInt32(1) << UInt32(bit))) != 0 {
+            mask[tokenID] = 0
+        }
+    }
+    return mask
+}
+
+private func percentile(_ sortedValues: [Double], _ p: Double) -> Double {
+    guard !sortedValues.isEmpty else { return 0 }
+    let index = Int((Double(sortedValues.count - 1) * p).rounded())
+    return sortedValues[index]
+}
+
+private func describe(results: [Double], label: String) {
+    let sorted = results.sorted()
+    let average = sorted.reduce(0, +) / Double(sorted.count)
+    print(
+        "\(label): avg \(String(format: "%.2f", average)) us, " +
+        "p50 \(String(format: "%.2f", percentile(sorted, 0.50))) us, " +
+        "p95 \(String(format: "%.2f", percentile(sorted, 0.95))) us"
+    )
+}
+
+@MainActor
+private func run() throws {
+    set_error_handler(errorHandler)
+
+    let vocab = ["<eos>"] + (0...0x0FFF).compactMap { UnicodeScalar($0).map(String.init) }
+    let payload = "structured-output"
+    let ebnfGrammar = #"root ::= ""# + payload + #"""#
+    let matcher = try NativeMatcher(vocab: vocab, stopTokenIds: [0], ebnfGrammar: ebnfGrammar)
+    defer { matcher.tearDown() }
+
+    let acceptedSequence = payload.map(String.init).compactMap { vocab.firstIndex(of: $0) }.map(Int32.init) + [0]
+    var bitmask = DLTensor.nextTokenBitmask(bufferSize: matcher.bufferSize)
+    defer { bitmask.deallocate() }
+    var denseMask = [Float](repeating: -.infinity, count: matcher.vocabSize)
+
+    let warmupIterations = 50
+    for _ in 0..<warmupIterations {
+        matcher.reset()
+        for token in acceptedSequence.dropLast() {
+            guard withUnsafeMutablePointer(to: &bitmask, { grammar_matcher_fill_next_token_bitmask(matcher.matcher, $0) }) else {
+                throw BenchmarkError.nativeError(errorCapture.take() ?? "fill_next_token_bitmask failed during warmup")
+            }
+            _ = oldSwiftStyleDenseMask(bitmaskTensor: &bitmask, vocabSize: matcher.vocabSize)
+            _ = grammar_matcher_accept_token_status(matcher.matcher, token)
+        }
+    }
+
+    let iterations = 200
+    var oldMaskSamples = [Double]()
+    var newMaskSamples = [Double]()
+    var oldAcceptSamples = [Double]()
+    var newAcceptSamples = [Double]()
+    oldMaskSamples.reserveCapacity(iterations)
+    newMaskSamples.reserveCapacity(iterations)
+    oldAcceptSamples.reserveCapacity(iterations)
+    newAcceptSamples.reserveCapacity(iterations)
+
+    let oldMaskAggregate = try benchmark(label: "old-mask", iterations: iterations) {
+        matcher.reset()
+        for token in acceptedSequence.dropLast() {
+            let clock = ContinuousClock()
+            let start = clock.now
+            guard withUnsafeMutablePointer(to: &bitmask, { grammar_matcher_fill_next_token_bitmask(matcher.matcher, $0) }) else {
+                throw BenchmarkError.nativeError(errorCapture.take() ?? "fill_next_token_bitmask failed")
+            }
+            _ = oldSwiftStyleDenseMask(bitmaskTensor: &bitmask, vocabSize: matcher.vocabSize)
+            let elapsed = start.duration(to: clock.now)
+            oldMaskSamples.append((Double(elapsed.components.seconds) + Double(elapsed.components.attoseconds) / 1e18) * 1_000_000)
+
+            let acceptStart = clock.now
+            if grammar_matcher_is_terminated(matcher.matcher) {
+                break
+            }
+            let accepted = grammar_matcher_accept_token(matcher.matcher, token)
+            let acceptElapsed = acceptStart.duration(to: clock.now)
+            oldAcceptSamples.append((Double(acceptElapsed.components.seconds) + Double(acceptElapsed.components.attoseconds) / 1e18) * 1_000_000)
+            if !accepted {
+                throw BenchmarkError.nativeError("old accept path rejected token \(token)")
+            }
+        }
+    }
+
+    let newMaskAggregate = try benchmark(label: "new-mask", iterations: iterations) {
+        matcher.reset()
+        for token in acceptedSequence.dropLast() {
+            let clock = ContinuousClock()
+            let start = clock.now
+            let filled = withUnsafeMutablePointer(to: &bitmask) { bitmaskPointer in
+                denseMask.withUnsafeMutableBufferPointer { denseMaskPointer in
+                    grammar_matcher_fill_next_token_dense_mask(
+                        matcher.matcher,
+                        bitmaskPointer,
+                        denseMaskPointer.baseAddress,
+                        denseMaskPointer.count
+                    )
+                }
+            }
+            let elapsed = start.duration(to: clock.now)
+            newMaskSamples.append((Double(elapsed.components.seconds) + Double(elapsed.components.attoseconds) / 1e18) * 1_000_000)
+            guard filled else {
+                throw BenchmarkError.nativeError(errorCapture.take() ?? "fill_next_token_dense_mask failed")
+            }
+
+            let acceptStart = clock.now
+            let status = grammar_matcher_accept_token_status(matcher.matcher, token)
+            let acceptElapsed = acceptStart.duration(to: clock.now)
+            newAcceptSamples.append((Double(acceptElapsed.components.seconds) + Double(acceptElapsed.components.attoseconds) / 1e18) * 1_000_000)
+            if status == 0 {
+                throw BenchmarkError.nativeError("new accept path rejected token \(token)")
+            }
+        }
+    }
+
+    print("Structured generation matcher microbenchmark")
+    print("Vocab size: \(matcher.vocabSize)")
+    print("Sequence length: \(acceptedSequence.count)")
+    print("Iterations: \(iterations)")
+    print("")
+
+    print("Mask path")
+    print(
+        "old total: \(String(format: "%.4f", oldMaskAggregate.totalSeconds)) s, " +
+        "\(String(format: "%.2f", oldMaskAggregate.microsecondsPerIteration)) us/iteration"
+    )
+    print(
+        "new total: \(String(format: "%.4f", newMaskAggregate.totalSeconds)) s, " +
+        "\(String(format: "%.2f", newMaskAggregate.microsecondsPerIteration)) us/iteration"
+    )
+    let maskSpeedup = oldMaskAggregate.totalSeconds / newMaskAggregate.totalSeconds
+    let maskReduction = (1 - (newMaskAggregate.totalSeconds / oldMaskAggregate.totalSeconds)) * 100
+    print(
+        "mask speedup: \(String(format: "%.2f", maskSpeedup))x " +
+        "(\(String(format: "%.1f", maskReduction))% less time)"
+    )
+    describe(results: oldMaskSamples, label: "old mask samples")
+    describe(results: newMaskSamples, label: "new mask samples")
+    print("")
+
+    let oldAcceptAverage = oldAcceptSamples.reduce(0, +) / Double(oldAcceptSamples.count)
+    let newAcceptAverage = newAcceptSamples.reduce(0, +) / Double(newAcceptSamples.count)
+    let acceptSpeedup = oldAcceptAverage / newAcceptAverage
+    let acceptReduction = (1 - (newAcceptAverage / oldAcceptAverage)) * 100
+    print("Accept path")
+    print("old avg: \(String(format: "%.2f", oldAcceptAverage)) us/call")
+    print("new avg: \(String(format: "%.2f", newAcceptAverage)) us/call")
+    print(
+        "accept speedup: \(String(format: "%.2f", acceptSpeedup))x " +
+        "(\(String(format: "%.1f", acceptReduction))% less time)"
+    )
+    describe(results: oldAcceptSamples, label: "old accept samples")
+    describe(results: newAcceptSamples, label: "new accept samples")
+}
+
+Task { @MainActor in
+    do {
+        try run()
+    } catch {
+        fputs("Benchmark failed: \(error)\n", stderr)
+        exit(1)
+    }
+    exit(0)
+}
+dispatchMain()


### PR DESCRIPTION
- `XGrammar.nextTokenMask()` no longer expands the packed matcher bitset through Swift-side `MLXArray` bitmap indexing, reshaping, slicing, and padding each token. It now reuses a preallocated `[Float]` buffer and asks native code to fill the dense `0 / -inf` mask directly.
- `XGrammar.advance(token:)` now uses a single native status call instead of doing `grammar_matcher_is_terminated()` plus `grammar_matcher_accept_token()` on every token.
- Added `MLXStructuredBenchmark`, which prints old-vs-new matcher-path timings with `swift run MLXStructuredBenchmark`.